### PR TITLE
Set Cargo profile defaults on predefined templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Detect if a linker is installed and don't display warning if it is (https://github.com/Kobzol/cargo-wizard/issues/5).
 - Validate profile name (https://github.com/Kobzol/cargo-wizard/issues/7).
+- Add support for the `incremental` profile attribute.
+- Set all performance-related default properties from the base profile (dev/release) on
+  templates (https://github.com/Kobzol/cargo-wizard/issues/4).
 
 # 0.2.1 (10. 3. 2024)
 

--- a/src/dialog/known_options.rs
+++ b/src/dialog/known_options.rs
@@ -219,6 +219,7 @@ impl KnownCargoOptions {
             TemplateItemId::Panic,
             TemplateItemId::DebugInfo,
             TemplateItemId::Strip,
+            TemplateItemId::Incremental,
             TemplateItemId::Linker,
             TemplateItemId::CodegenBackend,
             TemplateItemId::FrontendThreads,
@@ -313,6 +314,10 @@ impl KnownCargoOptions {
                     })
                     .build()
             },
+            TemplateItemId::Incremental => MetadataBuilder::default()
+                .bool("Enable", true)
+                .bool("Disable", false)
+                .build()
         }
     }
 }

--- a/src/dialog/prompts/customize_template.rs
+++ b/src/dialog/prompts/customize_template.rs
@@ -152,6 +152,7 @@ impl Display for ItemId {
             TemplateItemId::TargetCpuInstructionSet => "Target CPU instruction set",
             TemplateItemId::FrontendThreads => "Amount of frontend threads",
             TemplateItemId::Linker => "Linker",
+            TemplateItemId::Incremental => "Incremental compilation",
         };
         f.write_str(description)
     }

--- a/src/predefined.rs
+++ b/src/predefined.rs
@@ -25,10 +25,29 @@ impl PredefinedTemplateKind {
     }
 }
 
+fn dev_profile() -> TemplateBuilder {
+    TemplateBuilder::new(BuiltinProfile::Dev)
+        .item(TemplateItemId::OptimizationLevel, TomlValue::Int(0))
+        .item(TemplateItemId::DebugInfo, TomlValue::Bool(true))
+        .item(TemplateItemId::Strip, TomlValue::String("none".to_string()))
+        .item(TemplateItemId::Lto, TomlValue::Bool(false))
+        .item(TemplateItemId::CodegenUnits, TomlValue::Int(256))
+        .item(TemplateItemId::Incremental, TomlValue::Bool(true))
+}
+
+fn release_profile() -> TemplateBuilder {
+    TemplateBuilder::new(BuiltinProfile::Release)
+        .item(TemplateItemId::OptimizationLevel, TomlValue::Int(3))
+        .item(TemplateItemId::DebugInfo, TomlValue::Bool(false))
+        .item(TemplateItemId::Strip, TomlValue::String("none".to_string()))
+        .item(TemplateItemId::Lto, TomlValue::Bool(false))
+        .item(TemplateItemId::CodegenUnits, TomlValue::Int(16))
+        .item(TemplateItemId::Incremental, TomlValue::Bool(false))
+}
+
 /// Template that focuses on quick compile time.
 pub fn fast_compile_template(options: &WizardOptions) -> Template {
-    let mut builder = TemplateBuilder::new(BuiltinProfile::Dev)
-        .item(TemplateItemId::DebugInfo, TomlValue::int(0));
+    let mut builder = dev_profile().item(TemplateItemId::DebugInfo, TomlValue::int(0));
 
     #[cfg(unix)]
     {
@@ -51,7 +70,7 @@ pub fn fast_compile_template(options: &WizardOptions) -> Template {
 
 /// Template that focuses on maximum runtime performance.
 pub fn fast_runtime_template() -> Template {
-    TemplateBuilder::new(BuiltinProfile::Release)
+    release_profile()
         .item(TemplateItemId::Lto, TomlValue::bool(true))
         .item(TemplateItemId::CodegenUnits, TomlValue::int(1))
         .item(TemplateItemId::Panic, TomlValue::string("abort"))
@@ -64,8 +83,8 @@ pub fn fast_runtime_template() -> Template {
 
 /// Template that template focuses on minimal binary size.
 pub fn min_size_template() -> Template {
-    TemplateBuilder::new(BuiltinProfile::Release)
-        .item(TemplateItemId::DebugInfo, TomlValue::int(0))
+    release_profile()
+        .item(TemplateItemId::DebugInfo, TomlValue::bool(false))
         .item(TemplateItemId::Strip, TomlValue::bool(true))
         .item(TemplateItemId::Lto, TomlValue::bool(true))
         .item(TemplateItemId::OptimizationLevel, TomlValue::string("z"))

--- a/src/predefined.rs
+++ b/src/predefined.rs
@@ -1,7 +1,6 @@
-use crate::template::{TemplateBuilder, TemplateItemId};
+use crate::template::{dev_profile, release_profile, TemplateItemId};
 use crate::toml::TomlValue;
 use crate::utils::get_core_count;
-use crate::workspace::manifest::BuiltinProfile;
 use crate::{Template, WizardOptions};
 
 /// Enumeration of predefined templates.
@@ -23,26 +22,6 @@ impl PredefinedTemplateKind {
             PredefinedTemplateKind::MinSize => min_size_template(),
         }
     }
-}
-
-fn dev_profile() -> TemplateBuilder {
-    TemplateBuilder::new(BuiltinProfile::Dev)
-        .item(TemplateItemId::OptimizationLevel, TomlValue::Int(0))
-        .item(TemplateItemId::DebugInfo, TomlValue::Bool(true))
-        .item(TemplateItemId::Strip, TomlValue::String("none".to_string()))
-        .item(TemplateItemId::Lto, TomlValue::Bool(false))
-        .item(TemplateItemId::CodegenUnits, TomlValue::Int(256))
-        .item(TemplateItemId::Incremental, TomlValue::Bool(true))
-}
-
-fn release_profile() -> TemplateBuilder {
-    TemplateBuilder::new(BuiltinProfile::Release)
-        .item(TemplateItemId::OptimizationLevel, TomlValue::Int(3))
-        .item(TemplateItemId::DebugInfo, TomlValue::Bool(false))
-        .item(TemplateItemId::Strip, TomlValue::String("none".to_string()))
-        .item(TemplateItemId::Lto, TomlValue::Bool(false))
-        .item(TemplateItemId::CodegenUnits, TomlValue::Int(16))
-        .item(TemplateItemId::Incremental, TomlValue::Bool(false))
 }
 
 /// Template that focuses on quick compile time.

--- a/src/template.rs
+++ b/src/template.rs
@@ -48,7 +48,7 @@ impl TemplateBuilder {
     }
 
     pub fn item(mut self, id: TemplateItemId, value: TomlValue) -> Self {
-        assert!(self.profile.insert(id, value).is_none());
+        self.profile.insert(id, value);
         self
     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -71,6 +71,7 @@ pub enum TemplateItemId {
     CodegenUnits,
     Panic,
     OptimizationLevel,
+    Incremental,
     CodegenBackend,
     FrontendThreads,
     TargetCpuInstructionSet,

--- a/src/template.rs
+++ b/src/template.rs
@@ -61,6 +61,28 @@ impl TemplateBuilder {
     }
 }
 
+/// Default properties of the dev profile.
+pub fn dev_profile() -> TemplateBuilder {
+    TemplateBuilder::new(BuiltinProfile::Dev)
+        .item(TemplateItemId::OptimizationLevel, TomlValue::Int(0))
+        .item(TemplateItemId::DebugInfo, TomlValue::Bool(true))
+        .item(TemplateItemId::Strip, TomlValue::String("none".to_string()))
+        .item(TemplateItemId::Lto, TomlValue::Bool(false))
+        .item(TemplateItemId::CodegenUnits, TomlValue::Int(256))
+        .item(TemplateItemId::Incremental, TomlValue::Bool(true))
+}
+
+/// Default properties of the release profile.
+pub fn release_profile() -> TemplateBuilder {
+    TemplateBuilder::new(BuiltinProfile::Release)
+        .item(TemplateItemId::OptimizationLevel, TomlValue::Int(3))
+        .item(TemplateItemId::DebugInfo, TomlValue::Bool(false))
+        .item(TemplateItemId::Strip, TomlValue::String("none".to_string()))
+        .item(TemplateItemId::Lto, TomlValue::Bool(false))
+        .item(TemplateItemId::CodegenUnits, TomlValue::Int(16))
+        .item(TemplateItemId::Incremental, TomlValue::Bool(false))
+}
+
 /// Identifier of a specific item of a template.
 #[derive(Debug, Hash, Eq, PartialEq, Clone, Copy)]
 pub enum TemplateItemId {

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -57,7 +57,8 @@ impl CargoConfig {
                     | TemplateItemId::CodegenUnits
                     | TemplateItemId::Panic
                     | TemplateItemId::OptimizationLevel
-                    | TemplateItemId::CodegenBackend => None,
+                    | TemplateItemId::CodegenBackend
+                    | TemplateItemId::Incremental => None,
                 }
             })
             .collect();

--- a/src/workspace/manifest.rs
+++ b/src/workspace/manifest.rs
@@ -181,6 +181,7 @@ fn id_to_item_name(id: TemplateItemId) -> Option<&'static str> {
         TemplateItemId::Panic => Some("panic"),
         TemplateItemId::OptimizationLevel => Some("opt-level"),
         TemplateItemId::CodegenBackend => Some("codegen-backend"),
+        TemplateItemId::Incremental => Some("incremental"),
         TemplateItemId::TargetCpuInstructionSet
         | TemplateItemId::FrontendThreads
         | TemplateItemId::Linker => None,

--- a/tests/integration/apply.rs
+++ b/tests/integration/apply.rs
@@ -138,7 +138,12 @@ fn apply_missing_custom() -> anyhow::Result<()> {
 
     [profile.custom1]
     inherits = "dev"
+    opt-level = 0
     debug = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     "###);
 
     Ok(())
@@ -172,6 +177,11 @@ debug = 1
     [profile.custom1]
     inherits = "dev"
     debug = 0
+    opt-level = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     "###);
 
     Ok(())
@@ -231,8 +241,12 @@ fn apply_fast_runtime_template() -> anyhow::Result<()> {
 
     [profile.custom]
     inherits = "release"
+    opt-level = 3
+    debug = false
+    strip = "none"
     lto = true
     codegen-units = 1
+    incremental = false
     panic = "abort"
     "###);
 
@@ -258,9 +272,11 @@ fn apply_min_size_template() -> anyhow::Result<()> {
     [profile.custom]
     inherits = "release"
     opt-level = "z"
+    debug = false
     strip = true
     lto = true
     codegen-units = 1
+    incremental = false
     panic = "abort"
     "###);
 

--- a/tests/integration/apply.rs
+++ b/tests/integration/apply.rs
@@ -33,7 +33,12 @@ edition = "2021"
     edition = "2021"
 
     [profile.dev]
+    opt-level = 0
     debug = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     "###);
 
     Ok(())
@@ -65,12 +70,18 @@ members = ["bar"]
         .run()?
         .assert_ok();
     insta::assert_snapshot!(project.read_manifest(), @r###"
+
     [workspace]
     members = ["bar"]
 
     [profile.dev]
+    opt-level = 0
     debug = 0
-"###);
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
+    "###);
 
     Ok(())
 }
@@ -87,7 +98,12 @@ fn apply_missing_builtin() -> anyhow::Result<()> {
     edition = "2021"
 
     [profile.dev]
+    opt-level = 0
     debug = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     "###);
 
     Ok(())
@@ -111,6 +127,7 @@ debug = 1
 
     apply(&project, "dev", "fast-compile")?;
     insta::assert_snapshot!(project.read_manifest(), @r###"
+
     [package]
     name = "foo"
     version = "0.1.0"
@@ -118,6 +135,11 @@ debug = 1
 
     [profile.dev]
     debug = 0
+    opt-level = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     "###);
 
     Ok(())
@@ -136,7 +158,12 @@ fn apply_missing_custom() -> anyhow::Result<()> {
 
     [profile.custom1]
     inherits = "dev"
+    opt-level = 0
     debug = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     "###);
 
     Ok(())
@@ -161,6 +188,7 @@ debug = 1
 
     apply(&project, "custom1", "fast-compile")?;
     insta::assert_snapshot!(project.read_manifest(), @r###"
+
     [package]
     name = "foo"
     version = "0.1.0"
@@ -169,6 +197,11 @@ debug = 1
     [profile.custom1]
     inherits = "dev"
     debug = 0
+    opt-level = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     "###);
 
     Ok(())
@@ -205,11 +238,14 @@ codegen-units    = 10
 
     [profile.dev]
 
-    lto =      "thin"
+    lto =      false
 
     debug = 0   # Foo
 
-    codegen-units    = 10
+    codegen-units    = 256
+    opt-level = 0
+    strip = "none"
+    incremental = true
     "###);
 
     Ok(())
@@ -221,7 +257,6 @@ fn apply_fast_runtime_template() -> anyhow::Result<()> {
 
     apply(&project, "custom", "fast-runtime")?;
     insta::assert_snapshot!(project.read_manifest(), @r###"
-
     [package]
     name = "foo"
     version = "0.1.0"
@@ -229,8 +264,12 @@ fn apply_fast_runtime_template() -> anyhow::Result<()> {
 
     [profile.custom]
     inherits = "release"
+    opt-level = 3
+    debug = false
+    strip = "none"
     lto = true
     codegen-units = 1
+    incremental = false
     panic = "abort"
     "###);
 
@@ -248,7 +287,6 @@ fn apply_min_size_template() -> anyhow::Result<()> {
 
     apply(&project, "custom", "min-size")?;
     insta::assert_snapshot!(project.read_manifest(), @r###"
-
     [package]
     name = "foo"
     version = "0.1.0"
@@ -256,11 +294,12 @@ fn apply_min_size_template() -> anyhow::Result<()> {
 
     [profile.custom]
     inherits = "release"
-    debug = 0
+    opt-level = "z"
+    debug = false
     strip = true
     lto = true
-    opt-level = "z"
     codegen-units = 1
+    incremental = false
     panic = "abort"
     "###);
 

--- a/tests/integration/apply.rs
+++ b/tests/integration/apply.rs
@@ -218,11 +218,11 @@ codegen-units    = 10
 
     [profile.dev]
 
-    lto =      "thin"
+    lto =      false
 
     debug = 0   # Foo
 
-    codegen-units    = 10
+    codegen-units    = 256
     "###);
 
     Ok(())

--- a/tests/integration/apply.rs
+++ b/tests/integration/apply.rs
@@ -33,12 +33,7 @@ edition = "2021"
     edition = "2021"
 
     [profile.dev]
-    opt-level = 0
     debug = 0
-    strip = "none"
-    lto = false
-    codegen-units = 256
-    incremental = true
     "###);
 
     Ok(())
@@ -75,12 +70,7 @@ members = ["bar"]
     members = ["bar"]
 
     [profile.dev]
-    opt-level = 0
     debug = 0
-    strip = "none"
-    lto = false
-    codegen-units = 256
-    incremental = true
     "###);
 
     Ok(())
@@ -98,12 +88,7 @@ fn apply_missing_builtin() -> anyhow::Result<()> {
     edition = "2021"
 
     [profile.dev]
-    opt-level = 0
     debug = 0
-    strip = "none"
-    lto = false
-    codegen-units = 256
-    incremental = true
     "###);
 
     Ok(())
@@ -135,11 +120,6 @@ debug = 1
 
     [profile.dev]
     debug = 0
-    opt-level = 0
-    strip = "none"
-    lto = false
-    codegen-units = 256
-    incremental = true
     "###);
 
     Ok(())
@@ -158,12 +138,7 @@ fn apply_missing_custom() -> anyhow::Result<()> {
 
     [profile.custom1]
     inherits = "dev"
-    opt-level = 0
     debug = 0
-    strip = "none"
-    lto = false
-    codegen-units = 256
-    incremental = true
     "###);
 
     Ok(())
@@ -197,11 +172,6 @@ debug = 1
     [profile.custom1]
     inherits = "dev"
     debug = 0
-    opt-level = 0
-    strip = "none"
-    lto = false
-    codegen-units = 256
-    incremental = true
     "###);
 
     Ok(())
@@ -238,14 +208,11 @@ codegen-units    = 10
 
     [profile.dev]
 
-    lto =      false
+    lto =      "thin"
 
     debug = 0   # Foo
 
-    codegen-units    = 256
-    opt-level = 0
-    strip = "none"
-    incremental = true
+    codegen-units    = 10
     "###);
 
     Ok(())
@@ -264,12 +231,8 @@ fn apply_fast_runtime_template() -> anyhow::Result<()> {
 
     [profile.custom]
     inherits = "release"
-    opt-level = 3
-    debug = false
-    strip = "none"
     lto = true
     codegen-units = 1
-    incremental = false
     panic = "abort"
     "###);
 
@@ -295,11 +258,9 @@ fn apply_min_size_template() -> anyhow::Result<()> {
     [profile.custom]
     inherits = "release"
     opt-level = "z"
-    debug = false
     strip = true
     lto = true
     codegen-units = 1
-    incremental = false
     panic = "abort"
     "###);
 

--- a/tests/integration/dialog.rs
+++ b/tests/integration/dialog.rs
@@ -124,6 +124,11 @@ debug = 1
     [profile.custom1]
     inherits = "dev"
     debug = 0
+    opt-level = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     "###);
 
     Ok(())
@@ -146,7 +151,12 @@ fn dialog_fast_compile_to_new_profile() -> anyhow::Result<()> {
 
     [profile.custom1]
     inherits = "dev"
+    opt-level = 0
     debug = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     "###);
 
     Ok(())

--- a/tests/integration/dialog.rs
+++ b/tests/integration/dialog.rs
@@ -7,14 +7,18 @@ fn dialog_fast_compile_to_dev() -> anyhow::Result<()> {
     apply_profile(&project, "FastCompile", "dev")?;
 
     insta::assert_snapshot!(project.read_manifest(), @r###"
-
     [package]
     name = "foo"
     version = "0.1.0"
     edition = "2021"
 
     [profile.dev]
+    opt-level = 0
     debug = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     "###);
 
     insta::assert_snapshot!(project.read_config(), @r###"
@@ -38,11 +42,12 @@ fn dialog_min_size_to_release() -> anyhow::Result<()> {
     edition = "2021"
 
     [profile.release]
-    debug = 0
+    opt-level = "z"
+    debug = false
     strip = true
     lto = true
-    opt-level = "z"
     codegen-units = 1
+    incremental = false
     panic = "abort"
     "###);
 
@@ -126,6 +131,11 @@ debug = 1
     [profile.custom1]
     inherits = "dev"
     debug = 0
+    opt-level = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     "###);
 
     Ok(())
@@ -141,7 +151,6 @@ fn dialog_fast_compile_to_new_profile() -> anyhow::Result<()> {
         .run(&project)?;
 
     insta::assert_snapshot!(project.read_manifest(), @r###"
-
     [package]
     name = "foo"
     version = "0.1.0"
@@ -149,7 +158,12 @@ fn dialog_fast_compile_to_new_profile() -> anyhow::Result<()> {
 
     [profile.custom1]
     inherits = "dev"
+    opt-level = 0
     debug = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     "###);
 
     Ok(())
@@ -245,7 +259,12 @@ fn dialog_codegen_backend_add_cargo_features() -> anyhow::Result<()> {
     edition = "2021"
 
     [profile.dev]
+    opt-level = 0
     debug = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     codegen-backend = "cranelift"
     "###);
 
@@ -278,7 +297,12 @@ edition = "2021"
     edition = "2021"
 
     [profile.dev]
+    opt-level = 0
     debug = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     codegen-backend = "cranelift"
     "###);
 
@@ -331,7 +355,12 @@ fn dialog_fast_compile_nightly() -> anyhow::Result<()> {
     edition = "2021"
 
     [profile.dev]
+    opt-level = 0
     debug = 0
+    strip = "none"
+    lto = false
+    codegen-units = 256
+    incremental = true
     codegen-backend = "cranelift"
     "###);
 
@@ -359,8 +388,12 @@ fn dialog_unset_item() -> anyhow::Result<()> {
     edition = "2021"
 
     [profile.dev]
+    opt-level = 3
+    debug = false
+    strip = "none"
     lto = true
     codegen-units = 1
+    incremental = false
     "###);
 
     Ok(())

--- a/tests/integration/dialog.rs
+++ b/tests/integration/dialog.rs
@@ -13,12 +13,7 @@ fn dialog_fast_compile_to_dev() -> anyhow::Result<()> {
     edition = "2021"
 
     [profile.dev]
-    opt-level = 0
     debug = 0
-    strip = "none"
-    lto = false
-    codegen-units = 256
-    incremental = true
     "###);
 
     insta::assert_snapshot!(project.read_config(), @r###"
@@ -43,11 +38,9 @@ fn dialog_min_size_to_release() -> anyhow::Result<()> {
 
     [profile.release]
     opt-level = "z"
-    debug = false
     strip = true
     lto = true
     codegen-units = 1
-    incremental = false
     panic = "abort"
     "###);
 
@@ -131,11 +124,6 @@ debug = 1
     [profile.custom1]
     inherits = "dev"
     debug = 0
-    opt-level = 0
-    strip = "none"
-    lto = false
-    codegen-units = 256
-    incremental = true
     "###);
 
     Ok(())
@@ -158,12 +146,7 @@ fn dialog_fast_compile_to_new_profile() -> anyhow::Result<()> {
 
     [profile.custom1]
     inherits = "dev"
-    opt-level = 0
     debug = 0
-    strip = "none"
-    lto = false
-    codegen-units = 256
-    incremental = true
     "###);
 
     Ok(())
@@ -259,12 +242,7 @@ fn dialog_codegen_backend_add_cargo_features() -> anyhow::Result<()> {
     edition = "2021"
 
     [profile.dev]
-    opt-level = 0
     debug = 0
-    strip = "none"
-    lto = false
-    codegen-units = 256
-    incremental = true
     codegen-backend = "cranelift"
     "###);
 
@@ -297,12 +275,7 @@ edition = "2021"
     edition = "2021"
 
     [profile.dev]
-    opt-level = 0
     debug = 0
-    strip = "none"
-    lto = false
-    codegen-units = 256
-    incremental = true
     codegen-backend = "cranelift"
     "###);
 
@@ -355,12 +328,7 @@ fn dialog_fast_compile_nightly() -> anyhow::Result<()> {
     edition = "2021"
 
     [profile.dev]
-    opt-level = 0
     debug = 0
-    strip = "none"
-    lto = false
-    codegen-units = 256
-    incremental = true
     codegen-backend = "cranelift"
     "###);
 
@@ -388,12 +356,8 @@ fn dialog_unset_item() -> anyhow::Result<()> {
     edition = "2021"
 
     [profile.dev]
-    opt-level = 3
-    debug = false
-    strip = "none"
     lto = true
     codegen-units = 1
-    incremental = false
     "###);
 
     Ok(())


### PR DESCRIPTION
Before, the templates only modified attributes that were non-default for `dev`/`release`. Now, it modifies all performance relevant attributes, however if the template is applied directly to `dev` or `release`, it will skip the default values (unless they are already overwritten in the `[profile.dev/release]` table).

Fixes: https://github.com/Kobzol/cargo-wizard/issues/4